### PR TITLE
Replaced "entityId" with "entityID" + Fixed *bold* value

### DIFF
--- a/attrChecker.html
+++ b/attrChecker.html
@@ -61,7 +61,7 @@
                   <td><shibmlp Meta-displayName /></td>
                 </tr>
                  <tr>
-                   <td>entityId</td>
+                   <th>entityID</th>
                    <td><shibmlp entityID/></td>
                 </tr>
                 <tr>
@@ -89,31 +89,31 @@
                 <tbody>
 <!--TableStart-->
 <tr <shibmlpifnot SHIB_displayName> class='warning text-danger'</shibmlpifnot>>
-	<td>SHIB_displayName</td>
+	<th>SHIB_displayName</th>
 	<td><shibmlp SHIB_displayName /></td>
 </tr>
 <tr <shibmlpifnot SHIB_givenName> class='warning text-danger'</shibmlpifnot>>
-	<td>SHIB_givenName</td>
+	<th>SHIB_givenName</th>
 	<td><shibmlp SHIB_givenName /></td>
 </tr>
 <tr <shibmlpifnot SHIB_cn> class='warning text-danger'</shibmlpifnot>>
-	<td>SHIB_cn</td>
+	<th>SHIB_cn</th>
 	<td><shibmlp SHIB_cn /></td>
 </tr>
 <tr <shibmlpifnot SHIB_sn> class='warning text-danger'</shibmlpifnot>>
-	<td>SHIB_sn</td>
+	<th>SHIB_sn</th>
 	<td><shibmlp SHIB_sn /></td>
 </tr>
 <tr <shibmlpifnot SHIB_eduPersonPrincipalName> class='warning text-danger'</shibmlpifnot>>
-	<td>SHIB_eduPersonPrincipalName</td>
+	<th>SHIB_eduPersonPrincipalName</th>
 	<td><shibmlp SHIB_eduPersonPrincipalName /></td>
 </tr>
 <tr <shibmlpifnot SHIB_schacHomeOrganization> class='warning text-danger'</shibmlpifnot>>
-	<td>SHIB_schacHomeOrganization</td>
+	<th>SHIB_schacHomeOrganization</th>
 	<td><shibmlp SHIB_schacHomeOrganization /></td>
 </tr>
 <tr <shibmlpifnot SHIB_schacHomeOrganizationType> class='warning text-danger'</shibmlpifnot>>
-	<td>SHIB_schacHomeOrganizationType</td>
+	<th>SHIB_schacHomeOrganizationType</th>
 	<td><shibmlp SHIB_schacHomeOrganizationType /></td>
 </tr>
 <!--TableEnd-->


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3010502/147114874-6f2a860d-3525-452c-9445-3416d49cef71.png)

'entityId', 'affiliation' and 'persistent-id' without this change will not be "bold" in my example.
